### PR TITLE
Update README with -loader suffix to support Webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ npm install exports-loader
 ## Usage
 
 ``` javascript
-require("exports?file,parse=helpers.parse!./file.js");
+require("exports-loader?file,parse=helpers.parse!./file.js");
 // adds below code the the file's source:
 //  exports["file"] = file;
 //  exports["parse"] = helpers.parse;
 
-require("exports?file!./file.js");
+require("exports-loader?file!./file.js");
 // adds below code the the file's source:
 //  module.exports = file;
 ```


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra