### PR TITLE
Update source-map dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "exports loader module for webpack",
 	"dependencies": {
 		"loader-utils": "0.2.x",
-		"source-map": "0.1.x"
+		"source-map": "0.5.x"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
The API used here ([SourceNode.fromStringWithSourceMap](https://github.com/mozilla/source-map#sourcenodefromstringwithsourcemapcode-sourcemapconsumer-relativepath)) has not changed. But I don't know how to test this properly, so I haven't.